### PR TITLE
Check forbidden cacheability

### DIFF
--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -29,10 +29,11 @@ RSpec::Matchers.define :not_be_cached do
     response = RestClient::Request.responsify response.args[:url]  # again to prevent spurious cache miss
 
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
-    unless not_cached
+    if not_cached
+      true
+    else not_cached
       fail("x_cache header does not indicate an origin hit: '#{response.headers[:x_cache]}'")
     end
-    response.code == 200 && not_cached
   end
 end
 

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -31,7 +31,7 @@ RSpec::Matchers.define :not_be_cached do
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
     if not_cached
       true
-    else not_cached
+    else
       fail("x_cache header does not indicate an origin hit: '#{response.headers[:x_cache]}'")
     end
   end

--- a/lib/akamai_rspec/matchers/non_akamai.rb
+++ b/lib/akamai_rspec/matchers/non_akamai.rb
@@ -65,3 +65,11 @@ RSpec::Matchers.define :have_cookie do |cookie|
     response.cookies[cookie]
   end
 end
+
+RSpec::Matchers.define :be_forbidden do
+  match do |url|
+    response = RestClient::Request.responsify url
+    fail('Response was not forbidden') unless response.code == 403
+    true
+  end
+end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -21,6 +21,10 @@ module AkamaiRSpec
     def has_x_cache_headers(response)
       response.headers.keys.any? { |h| X_CACHE_HEADERS.include?(h) }
     end
+
+    def x_cache_headers
+      X_CACHE_HEADERS
+    end
   end
 end
 
@@ -36,7 +40,8 @@ end
 RSpec::Matchers.define :have_cp_code do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
-    match_fn = lambda { |header, expected| header.include?(expected) }
-    have_matching_x_cache_headers(url, contents, match_fn)
+    response = RestClient::Request.responsify url
+    has_x_cache_headers(response)
+    response.headers.any? { |key, value| x_cache_headers.include?(key) && value == contents }
   end
 end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -19,7 +19,7 @@ module AkamaiRSpec
     end
 
     def has_x_cache_headers(response)
-      unless X_CACHE_HEADERS.inject(false) { |bool, header| bool || response.headers.include?(header) }
+      unless response.headers.keys.any? { |h| X_CACHE_HEADERS.include?(h) }
         fail "Response does not contain the debug headers"
       end
     end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -7,7 +7,7 @@ module AkamaiRSpec
     def have_matching_x_cache_headers(url, contents, match_fn)
       response = RestClient::Request.responsify url
       has_x_cache_headers(response)
-      return true if x_cache_headers_match(response, contents, match_fn)
+      return false unless x_cache_headers_match(response, contents, match_fn)
       missing_x_cache_error(response, contents)
       response.code == 200
     end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -4,36 +4,16 @@ module AkamaiRSpec
   module Helpers
     X_CACHE_HEADERS = [:x_true_cache_key, :x_cache_key]
 
-    def have_matching_x_cache_headers(url, contents, match_fn)
-      response = RestClient::Request.responsify url
-      has_x_cache_headers(response)
-      return false unless x_cache_headers_match(response, contents, match_fn)
-      response.code == 200
-    end
-
-    def x_cache_headers_match(response, contents, match_fn)
-      X_CACHE_HEADERS.each do |key|
-        return true if response.headers[key] && match_fn.call(response.headers[key], contents)
-      end
-      false
-    end
-
-    def has_x_cache_headers(response)
-      response.headers.keys.any? { |h| X_CACHE_HEADERS.include?(h) }
-    end
-
     def x_cache_headers
       X_CACHE_HEADERS
     end
   end
 end
 
-
 RSpec::Matchers.define :be_served_from_origin do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
     response = RestClient::Request.responsify url
-    has_x_cache_headers(response)
     response.headers.any? { |key, value| x_cache_headers.include?(key) && value =~ /\/#{contents}\// } && \
       response.code == 200
   end
@@ -43,7 +23,6 @@ RSpec::Matchers.define :have_cp_code do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
     response = RestClient::Request.responsify url
-    has_x_cache_headers(response)
     response.headers.any? { |key, value| x_cache_headers.include?(key) && value == contents } && \
       response.code == 200
   end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -1,49 +1,62 @@
 require 'rspec'
 
-X_CACHE_HEADERS = [:x_true_cache_key, :x_cache_key]
+module AkamaiRSpec
+  module Helpers
+    X_CACHE_HEADERS = [:x_true_cache_key, :x_cache_key]
+
+    def have_matching_x_cache_headers(url, contents, match_fn)
+      response = RestClient::Request.responsify url
+      has_x_cache_headers(response)
+      return true if x_cache_headers_match(response, contents, match_fn)
+      missing_x_cache_error(response, contents)
+      response.code == 200
+    end
+
+    def x_cache_headers_match(response, contents, match_fn)
+      X_CACHE_HEADERS.each do |key|
+        return true if response.headers[key] && match_fn.call(response.headers[key], contents)
+      end
+      false
+    end
+
+    def has_x_cache_headers(response)
+      unless X_CACHE_HEADERS.inject(false) { |bool, header| bool || response.headers.include?(header) }
+        fail "Response does not contain the debug headers"
+      end
+    end
+
+    def missing_x_cache_error(response, contents)
+      X_CACHE_HEADERS.each do |key|
+        if (response.headers[key])
+          fail("#{key} has value '#{response.headers[key]}' which doesn't match '#{contents}'")
+        end
+      end
+    end
+  end
+end
+
 
 RSpec::Matchers.define :be_served_from_origin do |contents|
+  include AkamaiRSpec::Helpers
   match do |url|
     match_fn = lambda { |header, expected| header && header =~ /\/#{expected}\// }
-    expect(url).to have_matching_x_cache_headers(contents, match_fn)
+    have_matching_x_cache_headers(url, contents, match_fn)
   end
 end
 
 RSpec::Matchers.define :have_cp_code do |contents|
+  include AkamaiRSpec::Helpers
   match do |url|
     match_fn = lambda { |header, expected| header.include?(expected) }
-    expect(url).to have_matching_x_cache_headers(contents, match_fn)
+    have_matching_x_cache_headers(url, contents, match_fn)
   end
 end
 
 RSpec::Matchers.define :have_matching_x_cache_headers do |contents, match_fn|
+  include AkamaiRSpec::Helpers
   match do |url|
-    response = RestClient::Request.responsify url
-    has_x_cache_headers(response)
-    return true if x_cache_headers_match(response, contents, match_fn)
-    missing_x_cache_error(response, contents)
-    expect(response).to be_successful
+    have_matching_x_cache_headers(url, contents, match_fn)
   end
 end
 
-def x_cache_headers_match(response, contents, match_fn)
-  X_CACHE_HEADERS.each do |key|
-    return true if response.headers[key] && match_fn.call(response.headers[key], contents)
-  end
-  false
-end
-
-def has_x_cache_headers(response)
-  unless X_CACHE_HEADERS.inject(false) { |bool, header| bool || response.headers.include?(header) }
-    fail "Response does not contain the debug headers"
-  end
-end
-
-def missing_x_cache_error(response, contents)
-  X_CACHE_HEADERS.each do |key|
-    if (response.headers[key])
-      fail("#{key} has value '#{response.headers[key]}' which doesn't match '#{contents}'")
-    end
-  end
-end
 

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -8,7 +8,6 @@ module AkamaiRSpec
       response = RestClient::Request.responsify url
       has_x_cache_headers(response)
       return false unless x_cache_headers_match(response, contents, match_fn)
-      missing_x_cache_error(response, contents)
       response.code == 200
     end
 
@@ -22,14 +21,6 @@ module AkamaiRSpec
     def has_x_cache_headers(response)
       unless X_CACHE_HEADERS.inject(false) { |bool, header| bool || response.headers.include?(header) }
         fail "Response does not contain the debug headers"
-      end
-    end
-
-    def missing_x_cache_error(response, contents)
-      X_CACHE_HEADERS.each do |key|
-        if (response.headers[key])
-          fail("#{key} has value '#{response.headers[key]}' which doesn't match '#{contents}'")
-        end
       end
     end
   end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -32,8 +32,10 @@ end
 RSpec::Matchers.define :be_served_from_origin do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
-    match_fn = lambda { |header, expected| header && header =~ /\/#{expected}\// }
-    have_matching_x_cache_headers(url, contents, match_fn)
+    response = RestClient::Request.responsify url
+    has_x_cache_headers(response)
+    response.headers.any? { |key, value| x_cache_headers.include?(key) && value =~ /\/#{contents}\// } && \
+      response.code == 200
   end
 end
 
@@ -42,6 +44,7 @@ RSpec::Matchers.define :have_cp_code do |contents|
   match do |url|
     response = RestClient::Request.responsify url
     has_x_cache_headers(response)
-    response.headers.any? { |key, value| x_cache_headers.include?(key) && value == contents }
+    response.headers.any? { |key, value| x_cache_headers.include?(key) && value == contents } && \
+      response.code == 200
   end
 end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -19,9 +19,7 @@ module AkamaiRSpec
     end
 
     def has_x_cache_headers(response)
-      unless response.headers.keys.any? { |h| X_CACHE_HEADERS.include?(h) }
-        fail "Response does not contain the debug headers"
-      end
+      response.headers.keys.any? { |h| X_CACHE_HEADERS.include?(h) }
     end
   end
 end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -42,12 +42,3 @@ RSpec::Matchers.define :have_cp_code do |contents|
     have_matching_x_cache_headers(url, contents, match_fn)
   end
 end
-
-RSpec::Matchers.define :have_matching_x_cache_headers do |contents, match_fn|
-  include AkamaiRSpec::Helpers
-  match do |url|
-    have_matching_x_cache_headers(url, contents, match_fn)
-  end
-end
-
-

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -69,7 +69,12 @@ module RestClient
       if maybe_a_url.is_a? RestClient::Response
         maybe_a_url
       else
-        RestClient.get(maybe_a_url, akamai_debug_headers)
+        begin
+          RestClient.get(maybe_a_url, akamai_debug_headers)
+        rescue RestClient::RequestFailed => exception
+          # Return the original request
+          exception.response
+        end
       end
     end
 

--- a/spec/functional/non_akamai_spec.rb
+++ b/spec/functional/non_akamai_spec.rb
@@ -72,3 +72,23 @@ describe 'be_verifiably_secure' do
     expect(DOMAIN).to be_verifiably_secure(false)
   end
 end
+
+describe 'be_forbidden' do
+  before(:each) do
+    stub_status('/success', 200)
+    stub_status('/notfound', 404)
+    stub_status('/forbidden', 403)
+  end
+
+  it 'should pass when it gets a 403' do
+    expect(DOMAIN + '/forbidden').to be_forbidden
+  end
+
+  it 'should fail when it gets 404' do
+    expect { expect(DOMAIN + '/notfound').to be_forbidden }.to raise_error(RuntimeError)
+  end
+
+  it 'should fail when it gets 200' do
+    expect { expect(DOMAIN + '/success').to be_forbidden }.to raise_error(RuntimeError)
+  end
+end

--- a/spec/functional/x_cache_headers_spec.rb
+++ b/spec/functional/x_cache_headers_spec.rb
@@ -16,7 +16,7 @@ describe 'have_cp_code_set' do
   end
 
   it 'should fail when cp code is wrong' do
-    expect { expect(DOMAIN + '/correct').to have_cp_code('wrong') }.to raise_error(RuntimeError)
+    expect { expect(DOMAIN + '/correct').to have_cp_code('wrong') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should fail when both cache-key headers are not set' do
@@ -45,16 +45,16 @@ describe 'be_served_from_origin' do
 
   it 'should fail on 300 and correct origin' do
     expect { expect(DOMAIN + '/redirect').to be_served_from_origin('originsite.example.com') }
-      .to raise_error(RuntimeError)
+      .to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should fail on 200 and incorrect origin' do
     expect { expect(DOMAIN + '/correct').to be_served_from_origin('someothersite.example.com') }
-      .to raise_error(RuntimeError)
+      .to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should fail on 200 and origin that only partially matches' do
     expect { expect(DOMAIN + '/correct').to be_served_from_origin('site.example.com') }
-      .to raise_error(RuntimeError)
+      .to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end

--- a/spec/functional/x_cache_headers_spec.rb
+++ b/spec/functional/x_cache_headers_spec.rb
@@ -20,7 +20,7 @@ describe 'have_cp_code_set' do
   end
 
   it 'should fail when both cache-key headers are not set' do
-    expect { expect(DOMAIN + '/no-cp').to have_cp_code('wrong') }.to raise_error(RuntimeError)
+    expect { expect(DOMAIN + '/no-cp').to have_cp_code('wrong') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -61,4 +61,15 @@ describe RestClient::Request do
       expect(RestClient::Request.https_url(path)).to eq("https://#{prod_domain}/")
     end
   end
+
+  describe '#responsify' do
+    let(:url) { 'nonexistantdomain' }
+    before do
+      stub_request(:any, url).to_return(
+        body: 'abc', status: [500, 'message'])
+    end
+    it 'should not raise an exception when a RestClient exception is raised' do
+      expect { RestClient::Request.responsify(url) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
There is a good use case for checking a page is both forbidden and not cacheable.

We shouldn't be checking the response code inside the `not_be_cached` matcher, instead we should be chaining matchers together if required. This PR introduces this functionality, so you are able to do:

```
expect(url).to not_be_cached.and be_forbidden
```
