### PR TITLE
Implement our own get request class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rest-client', '~> 1.7.2'
+gem 'rest-client'
 gem 'rspec'
 gem 'rake'
 gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,14 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     json (1.8.1)
     method_source (0.8.2)
-    mime-types (2.4.3)
-    netrc (0.10.3)
+    mime-types (2.99)
+    netrc (0.11.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -21,7 +25,8 @@ GEM
       byebug (~> 4.0)
       pry (~> 0.10)
     rake (10.4.2)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (3.2.0)
@@ -39,6 +44,9 @@ GEM
     rspec-support (3.2.2)
     safe_yaml (1.0.4)
     slop (3.6.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -52,6 +60,9 @@ DEPENDENCIES
   pry
   pry-byebug
   rake
-  rest-client (~> 1.7.2)
+  rest-client
   rspec
   webmock
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -101,13 +101,6 @@ Expect the response to contain the specified cookie
 - Check that cache key contains Content Provider Code
 - 200 response
 
-## making requests
-```
-response = RestClient::Request::http_get(url, headers)
-response = RestClient::Request::https_get(url, headers)
-```
-Makes request to your base url that you set during initial configuration + ```url``` supplied in call.
-
 # Contributions
 We would be very thankful for any contributions, particularly documentation or tests.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ response headers
 
 #### ``` have_no_cache_set ```
 ```
-response = RestClient.get(url)
-expect(response).to have_no_cache_set
+expect(url).to have_no_cache_set
 ```
 Check that the header ```Cache-control = no-cache```
 
@@ -51,9 +50,7 @@ Requests the resource twice, and check that the 'x-cache' header says miss, and 
 
 #### ``` be_successful ```
 ```
-response = RestClient.get(url)
 expect(url).to be_successful
-expect(response).to be_successful
 ```
 
 expect a response code of 200
@@ -81,7 +78,7 @@ Check that akamai and origin cache headers correspond, and takes in to account e
 - Response code is 200
 
 #### ``` be_tier_distributed ```
-```expect(response).to be_tier_distributed```
+```expect(url).to be_tier_distributed```
 
 Forces a cache miss with a query string and checks that 'x_cache_remote' header is set.
 
@@ -91,15 +88,23 @@ Forces a cache miss with a query string and checks that 'x_cache_remote' header 
 Expect the response to be gzipped.
 
 #### ``` have_cookie ```
-```expect(response).to have_cookie cookie```
+```expect(url).to have_cookie cookie```
 
-Expect the response to contain the specified cookie
+Expect the url to contain the specified cookie
 
 #### ``` have_cp_code ```
 ```expect(url).to have_cp_code(cp_code)```
 
 - Check that cache key contains Content Provider Code
 - 200 response
+
+### Deprecated syntax
+
+Passing the response to the expectation.
+
+#### ``` have_cookie ```
+```expect(response).to have_cookie cookie```
+
 
 # Contributions
 We would be very thankful for any contributions, particularly documentation or tests.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The examples in the specs/functional folder have more details.
 To use the requests outside of matchers, you must configure your domain:
 
 ```
-RestClient::Request.prod_domain("www.example.com.edgesuite.net")
-RestClient::Request.stg_domain("www.example.com.edgesuite-staging.net")
+AkamaiRSpec::Request.prod_domain = "www.example.com.edgesuite.net"
+AkamaiRSpec::Request.stg_domain = "www.example.com.edgesuite-staging.net"
 ```
 
 The default akamai network used is prod, to test in staging you must specify.
 ```
-RestClient::Request.akamai_network("staging")
+AkamaiRSpec::Request.akamai_network = "staging"
 ```
 
 ### matchers

--- a/lib/akamai_rspec.rb
+++ b/lib/akamai_rspec.rb
@@ -1,3 +1,4 @@
 require 'akamai_rspec/akamai_headers'
 require 'akamai_rspec/matchers/matchers'
 require 'akamai_rspec/request'
+require 'akamai_rspec/response'

--- a/lib/akamai_rspec/akamai_headers.rb
+++ b/lib/akamai_rspec/akamai_headers.rb
@@ -1,5 +1,5 @@
 module AkamaiHeaders
-  def akamai_debug_headers
+  def self.akamai_debug_headers
     {
       pragma: 'akamai-x-cache-on, akamai-x-cache-remote-on, akamai-x-check-cacheable, akamai-x-get-cache-key, akamai-x-get-extracted-values, akamai-x-get-nonces, akamai-x-get-ssl-client-session-id, akamai-x-get-true-cache-key, akamai-x-serial-no'
     }

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 
 RSpec::Matchers.define :be_cacheable do
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     x_check_cacheable(response, 'YES')
     response.code == 200
   end
@@ -15,7 +15,7 @@ end
 
 RSpec::Matchers.define :have_no_cache_set do
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     cache_control = response.headers[:cache_control]
     fail('Cache-Control has been set') unless cache_control == 'no-cache'
     true
@@ -24,9 +24,9 @@ end
 
 RSpec::Matchers.define :not_be_cached do
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     x_check_cacheable(response, 'NO')
-    response = RestClient::Request.responsify response.args[:url]  # again to prevent spurious cache miss
+    response = AkamaiRSpec::Request.get response.args[:url]  # again to prevent spurious cache miss
 
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
     if not_cached
@@ -39,7 +39,7 @@ end
 
 RSpec::Matchers.define :be_tier_distributed do
   match do |url|
-    response = RestClient::Request.request_cache_miss(url)
+    response = AkamaiRSpec::Request.request_cache_miss(url)
     tiered = !response.headers[:x_cache_remote].nil?
     fail('No X-Cache-Remote header in response') unless tiered
     response.code == 200 && tiered

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :not_be_cached do
   match do |url|
     response = AkamaiRSpec::Request.get url
     x_check_cacheable(response, 'NO')
-    response = AkamaiRSpec::Request.get response.args[:url]  # again to prevent spurious cache miss
+    response = AkamaiRSpec::Request.get url  # again to prevent spurious cache miss
 
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
     if not_cached
@@ -39,7 +39,7 @@ end
 
 RSpec::Matchers.define :be_tier_distributed do
   match do |url|
-    response = AkamaiRSpec::Request.request_cache_miss(url)
+    response = AkamaiRSpec::Request.get_cache_miss(url)
     tiered = !response.headers[:x_cache_remote].nil?
     fail('No X-Cache-Remote header in response') unless tiered
     response.code == 200 && tiered

--- a/lib/akamai_rspec/matchers/honour_origin_headers.rb
+++ b/lib/akamai_rspec/matchers/honour_origin_headers.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :honour_origin_cache_headers do |origin, headers|
   fail("Headers must be one of: #{header_options}") unless header_options.include? headers
 
   match do |url|
-    akamai_response = RestClient::Request.responsify url
+    akamai_response = AkamaiRSpec::Request.get url
     origin_response = origin_response(origin)
     check_cache_control(origin_response, akamai_response, headers)
     check_expires(origin_response, akamai_response, headers)

--- a/lib/akamai_rspec/matchers/honour_origin_headers.rb
+++ b/lib/akamai_rspec/matchers/honour_origin_headers.rb
@@ -18,7 +18,7 @@ RSpec::Matchers.define :honour_origin_cache_headers do |origin, headers|
 end
 
 def fix_date_header(origin_response)
-  origin_response.headers[:date] = Time.now.httpdate unless origin_response.headers[:date]
+  origin_response.headers[:date] ||= Time.now.httpdate
   origin_response
 end
 

--- a/lib/akamai_rspec/matchers/non_akamai.rb
+++ b/lib/akamai_rspec/matchers/non_akamai.rb
@@ -51,7 +51,7 @@ end
 
 RSpec::Matchers.define :be_gzipped do
   match do |response_or_url|
-    response = AkamaiRSpec::Request.get response_or_url
+    response = AkamaiRSpec::Request.get_decode response_or_url
     response.headers[:content_encoding] == 'gzip'
   end
 end

--- a/lib/akamai_rspec/matchers/non_akamai.rb
+++ b/lib/akamai_rspec/matchers/non_akamai.rb
@@ -32,7 +32,7 @@ end
 
 RSpec::Matchers.define :be_successful do
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     fail('Response was not successful') unless response.code == 200
     true
   end
@@ -51,14 +51,14 @@ end
 
 RSpec::Matchers.define :be_gzipped do
   match do |response_or_url|
-    response = RestClient::Request.responsify response_or_url
+    response = AkamaiRSpec::Request.get response_or_url
     response.headers[:content_encoding] == 'gzip'
   end
 end
 
 RSpec::Matchers.define :have_cookie do |cookie|
   match do |response_or_url|
-    response = RestClient::Request.responsify response_or_url
+    response = AkamaiRSpec::Request.get response_or_url
     unless response.cookies[cookie]
       fail("Cookie #{cookie} not in #{response.cookies}")
     end

--- a/lib/akamai_rspec/matchers/non_akamai.rb
+++ b/lib/akamai_rspec/matchers/non_akamai.rb
@@ -68,7 +68,7 @@ end
 
 RSpec::Matchers.define :be_forbidden do
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     fail('Response was not forbidden') unless response.code == 403
     true
   end

--- a/lib/akamai_rspec/matchers/x_cache_headers.rb
+++ b/lib/akamai_rspec/matchers/x_cache_headers.rb
@@ -13,7 +13,7 @@ end
 RSpec::Matchers.define :be_served_from_origin do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     response.headers.any? { |key, value| x_cache_headers.include?(key) && value =~ /\/#{contents}\// } && \
       response.code == 200
   end
@@ -22,7 +22,7 @@ end
 RSpec::Matchers.define :have_cp_code do |contents|
   include AkamaiRSpec::Helpers
   match do |url|
-    response = RestClient::Request.responsify url
+    response = AkamaiRSpec::Request.get url
     response.headers.any? { |key, value| x_cache_headers.include?(key) && value == contents } && \
       response.code == 200
   end

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -28,6 +28,14 @@ module AkamaiRSpec
       new.get(url, AkamaiHeaders.akamai_debug_headers)
     end
 
+    def self.get_cache_miss(url)
+      url += url.include?('?') ? '&' : '?'
+      url += SecureRandom.hex
+      new.get(url, AkamaiHeaders.akamai_debug_headers)
+    end
+
+    attr_reader :response
+
     def initialize
       @@env ||= 'prod'
 

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -1,5 +1,5 @@
 require 'rest-client'
-require 'delegate'
+require 'forwardable'
 
 module AkamaiRSpec
   class Request

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -35,7 +35,7 @@ module AkamaiRSpec
                 when 'staging'
                   if @@akamai_stg_domain.nil?
                     raise ArgumentError.new(
-                      "You must set the prod domain: AkamaiRSpec.akamai_prod_domain = 'www.example.com.edgesuite.net'"
+                      "You must set the prod domain: AkamaiRSpec::Request.stg_domain = 'www.example.com.edgesuite.net'"
                     )
                   end
 
@@ -43,7 +43,7 @@ module AkamaiRSpec
                 else
                   if @@akamai_prod_domain.nil?
                     raise ArgumentError.new(
-                      "You must set the prod domain: AkamaiRSpec.akamai_prod_domain = 'www.example.com.edgesuite.net'"
+                      "You must set the prod domain: AkamaiRSpec::Request.prod_domain = 'www.example.com.edgesuite.net'"
                     )
                   end
 
@@ -79,6 +79,8 @@ module AkamaiRSpec
           []
         end
       end
+
+      headers
     end
 
     def build_request(uri, headers)

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -5,6 +5,9 @@ module AkamaiRSpec
   class Request
     extend Forwardable
 
+    @@akamai_stg_domain = nil
+    @@akamai_prod_domain = nil
+
     def self.stg_domain=(domain)
       @@akamai_stg_domain = domain
     end
@@ -30,8 +33,20 @@ module AkamaiRSpec
 
       @domain = case @@env.downcase
                 when 'staging'
+                  if @@akamai_stg_domain.nil?
+                    raise ArgumentError.new(
+                      "You must set the prod domain: AkamaiRSpec.akamai_prod_domain = 'www.example.com.edgesuite.net'"
+                    )
+                  end
+
                   @@akamai_stg_domain
                 else
+                  if @@akamai_prod_domain.nil?
+                    raise ArgumentError.new(
+                      "You must set the prod domain: AkamaiRSpec.akamai_prod_domain = 'www.example.com.edgesuite.net'"
+                    )
+                  end
+
                   @@akamai_prod_domain
                 end
 

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -74,9 +74,9 @@ module AkamaiRSpec
 
     def headers
       headers = Hash[@response.to_hash.map{ |k, v| [k.gsub(/-/,'_').downcase.to_sym, v] }]
-      headers.map do |k, v|
+      headers.each do |k, v|
         if v.is_a?(Array) && v.size == 1
-          []
+          headers[k] = v.first
         end
       end
 

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -34,8 +34,6 @@ module AkamaiRSpec
       new.get(url, AkamaiHeaders.akamai_debug_headers)
     end
 
-    attr_reader :response
-
     def initialize
       @@env ||= 'prod'
 
@@ -77,18 +75,7 @@ module AkamaiRSpec
         http.request(req, nil) { |http_response| http_response }
       end
 
-      self
-    end
-
-    def headers
-      headers = Hash[@response.to_hash.map{ |k, v| [k.gsub(/-/,'_').downcase.to_sym, v] }]
-      headers.each do |k, v|
-        if v.is_a?(Array) && v.size == 1
-          headers[k] = v.first
-        end
-      end
-
-      headers
+      AkamaiRSpec::Response.new(@response)
     end
 
     def build_request(uri, headers)

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -34,6 +34,12 @@ module AkamaiRSpec
       new.get(url, AkamaiHeaders.akamai_debug_headers)
     end
 
+    def self.get_decode(url)
+      response = new.get(url, AkamaiHeaders.akamai_debug_headers)
+      RestClient::Request.decode(response.headers[:content_encoding], response.body)
+      response
+    end
+
     def initialize
       @@env ||= 'prod'
 

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -70,6 +70,11 @@ module AkamaiRSpec
     delegate [:parse_url_with_auth, :stringify_headers] => :@rest_client
 
     def get(url, headers = {})
+      if url.is_a? RestClient::Response
+        warn 'This functionality is deprecated and will be removed in the next release'
+        return AkamaiRSpec::Response.new(url)
+      end
+
       uri = parse_url_with_auth(url)
 
       req = build_request(uri, stringify_headers(headers))

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -77,11 +77,11 @@ module AkamaiRSpec
       req['Host'] = uri.hostname
       uri.hostname = @domain
 
-      @response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+      response = Net::HTTP.start(uri.hostname, uri.port) do |http|
         http.request(req, nil) { |http_response| http_response }
       end
 
-      AkamaiRSpec::Response.new(@response)
+      AkamaiRSpec::Response.new(response)
     end
 
     def build_request(uri, headers)

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -1,93 +1,10 @@
 require 'rest-client'
-require 'akamai_rspec'
-
-module RestClient
-  class Request
-    @@akamai_network = 'prod'
-    @@akamai_stg_domain = 'overwrite me'
-    @@akamai_prod_domain = 'overwrite me'
-
-    def self.domain
-      env = @@akamai_network
-      case env.downcase
-      when 'staging'
-        @@akamai_stg_domain
-      else
-        @@akamai_prod_domain
-      end
-    end
-
-    def self.akamai_network(env)
-      @@akamai_network = env
-    end
-
-    def self.stg_domain(domain)
-      @@akamai_stg_domain = domain
-    end
-
-    def self.prod_domain(domain)
-      @@akamai_prod_domain = domain
-    end
-
-    def self.http_url(url)
-      url = "/#{url}" unless url.start_with?('/')
-      "http://#{domain}#{url}"
-    end
-
-    def self.https_url(url)
-      url = "/#{url}" unless url.start_with?('/')
-      "https://#{domain}#{url}"
-    end
-
-    def self.options
-      AkamaiHeaders.akamai_debug_headers
-    end
-
-    def self.http_get(url, options, cookies = {})
-      get_with_debug_headers(http_url(url), options, cookies)
-    end
-
-    def self.https_get(url, options, cookies = {})
-      get_with_debug_headers(https_url(url), options, cookies)
-    end
-
-    def self.get_with_debug_headers(url, options, cookies = {})
-      headers = options.merge(options).merge(cookies)
-      do_get_no_verify(url, headers) { |response, _, _| response }
-    end
-
-    def self.do_get_no_verify(url, additional_headers = {}, &block)
-      headers = (options[:headers] || {}).merge(additional_headers)
-      RestClient::Request.execute(options.merge(
-        method: :get,
-        url: url,
-        verify_ssl: false,
-        headers: headers), &(block || @block))
-    end
-
-    def self.responsify(maybe_a_url)
-      if maybe_a_url.is_a? RestClient::Response
-        maybe_a_url
-      else
-        begin
-          RestClient.get(maybe_a_url, options)
-        rescue RestClient::RequestFailed => exception
-          # Return the original request
-          exception.response
-        end
-      end
-    end
-
-    def self.request_cache_miss(url)
-      url += url.include?('?') ? '&' : '?'
-      url += SecureRandom.hex
-      RestClient.get(url, options)
-    end
-  end
-end
+require 'delegate'
 
 module AkamaiRSpec
   class Request
+    extend Forwardable
+
     def self.stg_domain=(domain)
       @@akamai_stg_domain = domain
     end
@@ -96,43 +13,56 @@ module AkamaiRSpec
       @@akamai_prod_domain = domain
     end
 
-    def initialize(env)
-      @env = env
-      @domain = case env.downcase
+    def self.network=(env)
+      @@env = env
+    end
+
+    def self.get(url)
+      new.get(url)
+    end
+
+    def self.get_with_debug_headers(url)
+      new.get(url, AkamaiHeaders.akamai_debug_headers)
+    end
+
+    def initialize
+      @@env ||= 'prod'
+
+      @domain = case @@env.downcase
                 when 'staging'
                   @@akamai_stg_domain
                 else
                   @@akamai_prod_domain
                 end
+
+      @rest_client = RestClient::Request.new(method: :get,
+                                              url: 'fakeurl.com',
+                                              verify_ssl: false)
     end
 
-    def get(url)
-      uri = parse_url(url)
+    delegate [:parse_url_with_auth, :stringify_headers] => :@rest_client
 
-      req = build_request(uri, headers)
+    def get(url, headers = {})
+      uri = parse_url_with_auth(url)
+
+      req = build_request(uri, stringify_headers(headers))
 
       req['Host'] = uri.hostname
       uri.hostname = @domain
 
-      Net::HTTP.start(uri.hostname, uri.port) do |http|
+      @response = Net::HTTP.start(uri.hostname, uri.port) do |http|
         http.request(req, nil) { |http_response| http_response }
       end
-    end
 
-    def parse_url(url)
-      uri = URI.parse(url)
-      if uri.hostname.nil?
-        raise URI::InvalidURIError.new("bad URI(no host provided): #{url}")
-      end
-
-      uri
+      self
     end
 
     def headers
-      AkamaiHeaders.akamai_debug_headers.inject({}) do |result, (key, value)|
-        key = key.to_s.capitalize
-        result[key] = value.to_s
-        result
+      headers = Hash[@response.to_hash.map{ |k, v| [k.gsub(/-/,'_').downcase.to_sym, v] }]
+      headers.map do |k, v|
+        if v.is_a?(Array) && v.size == 1
+          []
+        end
       end
     end
 

--- a/lib/akamai_rspec/response.rb
+++ b/lib/akamai_rspec/response.rb
@@ -19,6 +19,25 @@ module AkamaiRSpec
       @response.code.to_i
     end
 
+    def cookies
+      cookie_header = headers.to_hash[:set_cookie]
+      if cookie_header
+        if cookie_header.is_a?(Array)
+          cookies_string = cookie_header.collect do |header_value|
+            header_value.split('; ')
+          end
+          cookies_string.flatten!
+          cookies_array = cookies_string.collect { |c| c.split('=') }
+        else
+          cookies_array = [cookie_header.split('=')]
+        end
+
+        Hash[cookies_array]
+      else
+        {}
+      end
+    end
+
     def method_missing(method, *args)
       @response.send(method, *args)
     end

--- a/lib/akamai_rspec/response.rb
+++ b/lib/akamai_rspec/response.rb
@@ -1,0 +1,22 @@
+module AkamaiRSpec
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def headers
+      headers = Hash[@response.to_hash.map{ |k, v| [k.gsub(/-/,'_').downcase.to_sym, v] }]
+      headers.each do |k, v|
+        if v.is_a?(Array) && v.size == 1
+          headers[k] = v.first
+        end
+      end
+
+      headers
+    end
+
+    def method_missing(method, *args)
+      @response.send(method, *args)
+    end
+  end
+end

--- a/lib/akamai_rspec/response.rb
+++ b/lib/akamai_rspec/response.rb
@@ -15,6 +15,10 @@ module AkamaiRSpec
       headers
     end
 
+    def code
+      @response.code.to_i
+    end
+
     def method_missing(method, *args)
       @response.send(method, *args)
     end

--- a/spec/functional/matchers_spec.rb
+++ b/spec/functional/matchers_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'be_forwarded_to_index' do
   it 'should have tests' do
     pending
-    Fail
+    fail
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'webmock/rspec'
 require 'akamai_rspec'
 
 DOMAIN = 'www.example.com.edgesuite.net'
-RestClient::Request.prod_domain(DOMAIN)
+AkamaiRSpec::Request.prod_domain = DOMAIN
 
 def stub_headers(url, headers, body = 'abc')
   stub_request(:any, DOMAIN + url).to_return(

--- a/spec/unit/matchers/honour_origin_cache_headers_spec.rb
+++ b/spec/unit/matchers/honour_origin_cache_headers_spec.rb
@@ -5,6 +5,7 @@ require 'byebug'
 
 describe 'honour_origin_cache_headers' do
   context 'fix_date_header' do
+    let(:date) { Time.now }
     it 'should leave filled in date unchanged' do
       origin_response = double(RestClient::Response)
       allow(origin_response).to receive(:headers) { { :date => 'something' } }
@@ -12,10 +13,10 @@ describe 'honour_origin_cache_headers' do
     end
 
     it 'should fill in date if it is absent' do
-      pending
+      allow(Time).to receive(:now).and_return(date)
       origin_response = double(RestClient::Response)
       allow(origin_response).to receive(:headers) { { } }
-      expect(fix_date_header(origin_response).headers[:date]).to eq(Time.now.httpdate)
+      expect(fix_date_header(origin_response).headers[:date]).to eq(date.httpdate)
     end
 
   end

--- a/spec/unit/matchers/honour_origin_cache_headers_spec.rb
+++ b/spec/unit/matchers/honour_origin_cache_headers_spec.rb
@@ -6,6 +6,7 @@ require 'byebug'
 describe 'honour_origin_cache_headers' do
   context 'fix_date_header' do
     let(:date) { Time.now }
+    let(:headers) { {} }
     it 'should leave filled in date unchanged' do
       origin_response = double(RestClient::Response)
       allow(origin_response).to receive(:headers) { { :date => 'something' } }
@@ -15,7 +16,7 @@ describe 'honour_origin_cache_headers' do
     it 'should fill in date if it is absent' do
       allow(Time).to receive(:now).and_return(date)
       origin_response = double(RestClient::Response)
-      allow(origin_response).to receive(:headers) { { } }
+      allow(origin_response).to receive(:headers).and_return(headers)
       expect(fix_date_header(origin_response).headers[:date]).to eq(date.httpdate)
     end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -32,21 +32,4 @@ describe AkamaiRSpec::Request do
       end
     end
   end
-
-  describe '#headers' do
-    it 'returns a hash' do
-      expect(subject.headers).to be_a(Hash)
-    end
-
-    context 'header value is a single element array' do
-      before do
-        stub_request(:any, prod_domain).to_return(
-          body: 'abc', headers: { 'Bacon' => ['Yes'] }, status: [200, 'message'])
-      end
-
-      it 'returns a string' do
-        expect(subject.headers[:bacon]).to eq('Yes')
-      end
-    end
-  end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -37,5 +37,16 @@ describe AkamaiRSpec::Request do
     it 'returns a hash' do
       expect(subject.headers).to be_a(Hash)
     end
+
+    context 'header value is a single element array' do
+      before do
+        stub_request(:any, prod_domain).to_return(
+          body: 'abc', headers: { 'Bacon' => ['Yes'] }, status: [200, 'message'])
+      end
+
+      it 'returns a string' do
+        expect(subject.headers[:bacon]).to eq('Yes')
+      end
+    end
   end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -14,9 +14,9 @@ describe AkamaiRSpec::Request do
     stub_status(stg_domain, 200)
   end
 
-  describe '#get' do
-    subject { described_class.get(url) }
+  subject { described_class.get(url) }
 
+  describe '#get' do
     context 'prod domain' do
       it 'queries the right domain' do
         expect(Net::HTTP).to receive(:start).with(prod_domain, anything)
@@ -30,6 +30,12 @@ describe AkamaiRSpec::Request do
         expect(Net::HTTP).to receive(:start).with(stg_domain, anything)
         subject
       end
+    end
+  end
+
+  describe '#headers' do
+    it 'returns a hash' do
+      expect(subject.headers).to be_a(Hash)
     end
   end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -73,3 +73,32 @@ describe RestClient::Request do
     end
   end
 end
+
+describe AkamaiRSpec::Request do
+  let(:stg_domain) { 'www.example.com.edgesuite-staging.net' }
+  let(:prod_domain) { 'www.example.com.edgesuite.net' }
+  let(:network) { 'prod' }
+  before do
+    AkamaiRSpec::Request.stg_domain = stg_domain
+    AkamaiRSpec::Request.prod_domain = prod_domain
+  end
+
+  subject { described_class.new(network).get('http://examples.com') }
+
+  describe '#get' do
+    context 'prod domain' do
+      it 'queries the right domain' do
+        expect(Net::HTTP).to receive(:start).with(prod_domain, anything)
+        subject
+      end
+    end
+
+    context 'stating domain' do
+      let(:network) { 'staging' }
+      it 'quereis the right domain' do
+        expect(Net::HTTP).to receive(:start).with(stg_domain, anything)
+        subject
+      end
+    end
+  end
+end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1,91 +1,22 @@
 require 'spec_helper'
 require 'rspec/expectations'
-require 'rest-client'
-
-describe RestClient::Request do
-  let(:stg_domain) { 'www.example.com.edgesuite-staging.net' }
-  let(:prod_domain) { 'www.example.com.edgesuite.net' }
-  before do
-    RestClient::Request.stg_domain(stg_domain)
-    RestClient::Request.prod_domain(prod_domain)
-  end
-
-  describe '#domain' do
-    it 'should select staging' do
-      RestClient::Request.akamai_network('staging')
-      expect(RestClient::Request.domain).to eq(stg_domain)
-    end
-
-    it 'should default to prod' do
-      RestClient::Request.akamai_network('not staging')
-      expect(RestClient::Request.domain).to eq(prod_domain)
-    end
-  end
-
-  describe '#http_url' do
-    it 'should succeed without leading /' do
-      path = 'something'
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.http_url(path)).to eq("http://#{prod_domain}/#{path}")
-    end
-
-    it 'should succeed with a leading /' do
-      path = '/something'
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.http_url(path)).to eq("http://#{prod_domain}#{path}")
-    end
-
-    it 'should succeed with an empty path' do
-      path = ''
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.http_url(path)).to eq("http://#{prod_domain}/")
-    end
-  end
-
-  describe '#https_url' do
-    it 'should succeed without leading /' do
-      path = 'something'
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.https_url(path)).to eq("https://#{prod_domain}/#{path}")
-    end
-
-    it 'should succeed with a leading /' do
-      path = '/something'
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.https_url(path)).to eq("https://#{prod_domain}#{path}")
-    end
-
-    it 'should succeed with an empty path' do
-      path = ''
-      RestClient::Request.akamai_network('prod')
-      expect(RestClient::Request.https_url(path)).to eq("https://#{prod_domain}/")
-    end
-  end
-
-  describe '#responsify' do
-    let(:url) { 'nonexistantdomain' }
-    before do
-      stub_request(:any, url).to_return(
-        body: 'abc', status: [500, 'message'])
-    end
-    it 'should not raise an exception when a RestClient exception is raised' do
-      expect { RestClient::Request.responsify(url) }.to_not raise_error
-    end
-  end
-end
 
 describe AkamaiRSpec::Request do
   let(:stg_domain) { 'www.example.com.edgesuite-staging.net' }
   let(:prod_domain) { 'www.example.com.edgesuite.net' }
+  let(:url) { 'example.com' }
   let(:network) { 'prod' }
   before do
     AkamaiRSpec::Request.stg_domain = stg_domain
     AkamaiRSpec::Request.prod_domain = prod_domain
+    AkamaiRSpec::Request.network = network
+    stub_status(prod_domain, 200)
+    stub_status(stg_domain, 200)
   end
 
-  subject { described_class.new(network).get('http://examples.com') }
-
   describe '#get' do
+    subject { described_class.get(url) }
+
     context 'prod domain' do
       it 'queries the right domain' do
         expect(Net::HTTP).to receive(:start).with(prod_domain, anything)
@@ -93,7 +24,7 @@ describe AkamaiRSpec::Request do
       end
     end
 
-    context 'stating domain' do
+    context 'staging domain' do
       let(:network) { 'staging' }
       it 'quereis the right domain' do
         expect(Net::HTTP).to receive(:start).with(stg_domain, anything)

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe AkamaiRSpec::Response do
+  let(:response) { double(Net::HTTPResponse) }
+  subject { described_class.new(response) }
+
+  describe '#headers' do
+    before do
+      expect(response).to receive(:to_hash).and_return(headers)
+    end
+
+    context 'headers are empty' do
+      let(:headers) { {} }
+      it 'returns a hash' do
+        expect(subject.headers).to be_a(Hash)
+      end
+    end
+
+    context 'header value is a single element array' do
+      let(:headers) { {"Bacon" => ["Yes"]} }
+      it 'returns a string' do
+        expect(subject.headers[:bacon]).to eq('Yes')
+      end
+
+      it 'converts keys to symbols' do
+        expect(subject.headers.keys).to include(:bacon)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a rather large refactor of the Request class. We remove the monkey patch of RestClient::Request and implement our own get mechanism, using Net::HTTP. We re-use some of the RestClient::Request public methods to DRY it up, but I'm still undecided if it would be better to copy and paste the code from that library, to prevent future API changes from breaking this library.

There's a lot of refactoring that could have been done, and in fact was at first, but I've avoided doing so as this PR is already quite large.
