### PR TITLE
Use our Request library, not RestClient

### DIFF
--- a/lib/akamai_rspec/matchers/redirects.rb
+++ b/lib/akamai_rspec/matchers/redirects.rb
@@ -19,7 +19,7 @@ RSpec::Matchers.define :be_temporarily_redirected_with_trailing_slash do
 end
 
 def redirect(url, expected_location, expected_response_code)
-  response = RestClient.get(url) { |response, _, _| response }
+  response = AkamaiRSpec::Request.get(url)
   fail "response was #{response.code}" unless response.code == expected_response_code
   unless response.headers[:location] == expected_location
     fail "redirect location was #{response.headers[:location]} (expected #{expected_location})"


### PR DESCRIPTION
## Context

I spent a lot of time refactoring AkamaiRSpec so it does not monkey patch `RestClient`, but I appear to have missed some spots that still rely on that non-existant monkey patch.
## Changes

Use our Request library
## Considerations

There are a couple of other spots to fix this in:

```
lib/akamai_rspec/matchers/honour_origin_headers.rb
lib/akamai_rspec/matchers/matchers.rb
lib/akamai_rspec/matchers/non_akamai.rb
```

But they require some extra work.
