### PR TITLE
Add `be_served_from_netstorage` matcher

### DIFF
--- a/lib/akamai_rspec/matchers/matchers.rb
+++ b/lib/akamai_rspec/matchers/matchers.rb
@@ -5,6 +5,8 @@ require_relative 'caching'
 require_relative 'non_akamai'
 require_relative 'honour_origin_headers'
 require_relative 'x_cache_headers'
+require_relative 'netstorage'
+
 include AkamaiHeaders
 
 RSpec::Matchers.define :be_forwarded_to_index do |channel|

--- a/lib/akamai_rspec/matchers/netstorage.rb
+++ b/lib/akamai_rspec/matchers/netstorage.rb
@@ -1,0 +1,17 @@
+require 'rspec'
+
+RSpec::Matchers.define :be_served_from_netstorage do
+  match do |url|
+    served_from_netstorage?(url)
+  end
+end
+
+def served_from_netstorage?(url)
+  response = AkamaiRSpec::Request.get_with_debug_headers(url)
+
+  if response.headers[:x_true_cache_key].include?(NETSTORAGE_DOMAIN)
+    true
+  else
+    false
+  end
+end

--- a/lib/akamai_rspec/matchers/netstorage.rb
+++ b/lib/akamai_rspec/matchers/netstorage.rb
@@ -8,10 +8,5 @@ end
 
 def served_from_netstorage?(url)
   response = AkamaiRSpec::Request.get_with_debug_headers(url)
-
-  if response.headers[:x_true_cache_key].include?(NETSTORAGE_DOMAIN)
-    true
-  else
-    false
-  end
+  response.headers[:x_true_cache_key].include?(NETSTORAGE_DOMAIN)
 end

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -7,6 +7,7 @@ module AkamaiRSpec
 
     @@akamai_stg_domain = nil
     @@akamai_prod_domain = nil
+    @@akamai_netstorage_domain = nil
 
     def self.stg_domain=(domain)
       @@akamai_stg_domain = domain
@@ -17,7 +18,12 @@ module AkamaiRSpec
     end
 
     def self.network=(env)
+      STDERR.puts "AkamaiRSpec.Request: setting network to #{env}"
       @@env = env
+    end
+
+    def self.netstorage_domain=(domain)
+      @@akamai_netstorage_domain = domain
     end
 
     def self.get(url, headers={})

--- a/spec/functional/netstorage_spec.rb
+++ b/spec/functional/netstorage_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'be_served_from_netstorage' do
+  before(:each) do
+    stub_headers('/netstorage', 'X-True-Cache-Key' => "S/=/12345/123456/1m/#{NETSTORAGE_DOMAIN}/1234/error.html")
+    stub_headers('/', 'X-True-Cache-Key' => "/D/000/#{DOMAIN}/example")
+  end
+
+  it 'should succeed when netstorage domain is present' do
+    expect(DOMAIN + '/netstorage').to be_served_from_netstorage
+  end
+
+  it 'should fail when netstorage domain is not present' do
+    expect(DOMAIN + '/').to_not be_served_from_netstorage
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,9 @@ require 'akamai_rspec'
 DOMAIN = 'www.example.com.edgesuite.net'
 AkamaiRSpec::Request.prod_domain = DOMAIN
 
+NETSTORAGE_DOMAIN = 'example.download.akamai.com'
+AkamaiRSpec::Request.netstorage_domain = NETSTORAGE_DOMAIN
+
 def stub_headers(url, headers, body = 'abc')
   stub_request(:any, DOMAIN + url).to_return(
     body: body, headers: headers)


### PR DESCRIPTION
Creates a new matcher `be_served_from_netstorage` to assist us in
testing that our custom error pages are being served from netstorage in
scenarios where we are expecting the origin to respond but have the
content served from the edge. Some examples of this are AWS WAF 403's
and origin read timeouts.