### PR TITLE
Negatable caching tests

### DIFF
--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -66,6 +66,10 @@ RSpec::Matchers.define :be_tier_distributed do
   failure_message do
     'No X-Cache-Remote header in response'
   end
+
+  failure_message_when_negated do
+    'X-Cache-Remote header in response'
+  end
 end
 
 def x_check_cacheable(response, should_be_cacheable)

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -3,9 +3,13 @@ require 'securerandom'
 
 RSpec::Matchers.define :be_cacheable do
   match do |url|
+    @error = ""
     response = AkamaiRSpec::Request.get_with_debug_headers url
-    x_check_cacheable(response, 'YES')
-    response.code == 200
+    x_check_cacheable(response, 'YES') && response.code == 200
+  end
+
+  failure_message do
+    @error
   end
 end
 
@@ -17,23 +21,38 @@ RSpec::Matchers.define :have_no_cache_set do
   match do |url|
     response = AkamaiRSpec::Request.get url
     cache_control = response.headers[:cache_control]
-    fail('Cache-Control has been set') unless cache_control == 'no-cache'
-    true
+    cache_control == 'no-cache'
+  end
+
+  failure_message do
+    "Cache-Control has been set to '#{response.headers[:cache_control]}' expected 'no-cache'"
+  end
+
+  failure_message_when_negated do
+    "Cache-Control has been set to 'no-cache'"
   end
 end
 
 RSpec::Matchers.define :not_be_cached do
+
   match do |url|
+    @error = ""
     response = AkamaiRSpec::Request.get_with_debug_headers url
-    x_check_cacheable(response, 'NO')
+    not_cacheable = x_check_cacheable(response, 'NO')
     response = AkamaiRSpec::Request.get_with_debug_headers url  # again to prevent spurious cache miss
 
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
-    if not_cached
+    if not_cached && not_cacheable
       true
     else
-      fail("x_cache header does not indicate an origin hit: '#{response.headers[:x_cache]}'")
+      msg = "x_cache header does not indicate an origin hit: '#{response.headers[:x_cache]}'"
+      @error.length > 0 ? @error += "\n#{msg}" : @error = msg
+      false
     end
+  end
+
+  failure_message do
+    @error
   end
 end
 
@@ -41,15 +60,23 @@ RSpec::Matchers.define :be_tier_distributed do
   match do |url|
     response = AkamaiRSpec::Request.get_cache_miss(url)
     tiered = !response.headers[:x_cache_remote].nil?
-    fail('No X-Cache-Remote header in response') unless tiered
     response.code == 200 && tiered
+  end
+
+  failure_message do
+    'No X-Cache-Remote header in response'
   end
 end
 
 def x_check_cacheable(response, should_be_cacheable)
   x_check_cacheable = response.headers[:x_check_cacheable]
-  fail('No X-Check-Cacheable header?') if x_check_cacheable.nil?
-  unless (x_check_cacheable == should_be_cacheable)
-    fail("X-Check-Cacheable header is: #{x_check_cacheable} expected #{should_be_cacheable}")
+  if x_check_cacheable.nil?
+    @error = 'No X-Check-Cacheable header?'
+    false
+  elsif (x_check_cacheable != should_be_cacheable)
+    @error = "X-Check-Cacheable header is: #{x_check_cacheable} expected #{should_be_cacheable}"
+    false
+  else
+    true
   end
 end

--- a/spec/functional/caching_spec.rb
+++ b/spec/functional/caching_spec.rb
@@ -30,6 +30,32 @@ describe 'have_no_cache_set' do
   end
 end
 
+describe 'be_cached' do
+  before(:each) do
+    stub_headers('/cacheable_but_miss', 'X-Check-Cacheable' => 'YES', 'X-Cache' => 'TCP_MISS')
+    stub_headers('/not_cacheable', 'X-Check-Cacheable' => 'NO', 'X-Cache' => 'TCP_MISS')
+    stub_headers('/cacheable_and_cached', 'X-Check-Cacheable' => 'YES', 'X-Cache' => 'TCP_HIT')
+    stub_headers('/not_cacheable_but_cached', 'X-Check-Cacheable' => 'NO', 'X-Cache' => 'TCP_HIT')
+  end
+
+  it 'should succeed when cacheable and cached' do
+    expect(DOMAIN + '/cacheable_and_cached').to be_cached
+  end
+
+  it 'should fail when not cacheable' do
+    expect(DOMAIN + '/not_cacheable').not_to be_cached
+  end
+
+  it 'should fail when cacheable but missed' do
+    expect(DOMAIN + '/cacheable_but_miss').not_to be_cached
+  end
+
+  it 'should fail when supposedly not cacheable but cached anyway' do
+    expect(DOMAIN + '/not_cacheable_but_cached').not_to be_cached
+  end
+
+end
+
 describe 'not_be_cached' do
   before(:each) do
     stub_headers('/cacheable_but_miss', 'X-Check-Cacheable' => 'YES', 'X-Cache' => 'TCP_MISS')

--- a/spec/functional/caching_spec.rb
+++ b/spec/functional/caching_spec.rb
@@ -11,7 +11,7 @@ describe 'be_cacheable' do
   end
 
   it 'should fail when not cacheable' do
-    expect { expect(DOMAIN + '/not_cacheable').to be_cacheable }.to raise_error(RuntimeError)
+    expect(DOMAIN + '/not_cacheable').not_to be_cacheable
   end
 end
 
@@ -26,7 +26,7 @@ describe 'have_no_cache_set' do
   end
 
   it 'should fail when cacheable' do
-    expect { expect(DOMAIN + '/cacheable').to have_no_cache_set }.to raise_error(RuntimeError)
+    expect(DOMAIN + '/cacheable').not_to have_no_cache_set
   end
 end
 
@@ -43,17 +43,15 @@ describe 'not_be_cached' do
   end
 
   it 'should fail when cacheable but missed' do
-    expect { expect(DOMAIN + '/cacheable_but_miss').to not_be_cached }.to raise_error(RuntimeError)
+    expect(DOMAIN + '/cacheable_but_miss').not_to not_be_cached
   end
 
   it 'should fail when supposedly not cacheable but cached anyway' do
-    expect { expect(DOMAIN + '/not_cacheable_but_cached').to not_be_cached }
-      .to raise_error(RuntimeError)
+    expect(DOMAIN + '/not_cacheable_but_cached').not_to not_be_cached
   end
 
   it 'should fail when cacheable and cached' do
-    expect { expect(DOMAIN + '/cacheable_and_cached').to not_be_cached }
-      .to raise_error(RuntimeError)
+    expect(DOMAIN + '/cacheable_and_cached').not_to not_be_cached
   end
 end
 
@@ -72,6 +70,6 @@ describe 'be_tier_distributed' do
   end
 
   it 'should fail when not remotely cached' do
-    expect { expect(DOMAIN + '/not_cacheable').to be_tier_distributed }.to raise_error(RuntimeError)
+    expect(DOMAIN + '/not_cacheable').not_to be_tier_distributed
   end
 end


### PR DESCRIPTION
This PR was prompted by wanting to test whether a `url` was not cacheable and `expect(url).not_to be_cacheable` not working as expected.

This PR refactors the caching tests to not raise an exception on failure, ie. `not_to`, but instead use `failure_message` and return false on failure.