### PR TITLE
Clean out "internal" Akamai functionality headers

### DIFF
--- a/lib/akamai_rspec/matchers/honour_origin_headers.rb
+++ b/lib/akamai_rspec/matchers/honour_origin_headers.rb
@@ -30,7 +30,16 @@ def clean_cc_directives(origin_response, akamai_response)
   origin_cc_directives = origin_response.headers[:cache_control].split(/[, ]+/).to_set
   akamai_cc_directives = akamai_response.headers[:cache_control].split(/[, ]+/).to_set
 
-  origin_cc_directives.delete 'must-revalidate' # as Akamai does no pass it on
+  unwanted_values = %w(
+    must-revalidate
+    stale-if-error
+    stale-while-revalidate
+  )
+
+  unwanted_values.each do |unwanted_value|
+    origin_cc_directives.delete_if { |key, _| key.include?(unwanted_value) }
+  end
+
   return origin_cc_directives, akamai_cc_directives
 end
 

--- a/spec/functional/honour_origin_cache_headers_spec.rb
+++ b/spec/functional/honour_origin_cache_headers_spec.rb
@@ -65,4 +65,13 @@ describe 'honour_origin_cache_headers' do
       expect(DOMAIN + '/stuff').to honour_origin_cache_headers(origin)
     }.to raise_error(/Origin sent .* but Akamai sent/)
   end
+
+  it 'ignores unwanted headers' do
+    origin = 'http://www.example.com/stuff'
+    headers1 = { 'cache-control' => 'public, max-age=10','expires' => a_date_in_the_future }
+    headers2 = { 'cache-control' => 'public, max-age=10, stale-while-revalidate=10, stale-if-error=10, must-revalidate','expires' => a_date_in_the_future }
+    stub_request(:any, DOMAIN + '/stuff').to_return(body: 'body', headers: headers1)
+    stub_request(:any, origin).to_return(body: 'body', headers: headers2)
+    expect(DOMAIN + '/stuff').to honour_origin_cache_headers(origin)
+  end
 end

--- a/spec/functional/honour_origin_cache_headers_spec.rb
+++ b/spec/functional/honour_origin_cache_headers_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe 'honour_origin_cache_headers' do
 
   let(:a_date_in_the_future) { 'Thu, 01 Dec 2015 07:00:00 GMT' }

--- a/spec/unit/matchers/honour_origin_cache_headers_spec.rb
+++ b/spec/unit/matchers/honour_origin_cache_headers_spec.rb
@@ -18,6 +18,5 @@ describe 'honour_origin_cache_headers' do
       allow(origin_response).to receive(:headers).and_return(headers)
       expect(fix_date_header(origin_response).headers[:date]).to eq(date.httpdate)
     end
-
   end
 end


### PR DESCRIPTION
Akamai uses a bunch of functionality behind the scenes which they mix into
their product that is never passed onto the downstream. A few of these
things are:

- Ensuring revalidation with the origin (`must-revalidate`)
- Handle serving cached copies of resources should the origin be
 unavailable (`stale-if-error`)
- Refreshing content asynchronously after expiry
 (`stale-while-revalidate`)

The issue with this is that when you apply these cache control values to
your origin and the traffic is coming via another provider, the
`honour_origin_headers` matcher will fail due to Akamai swallowing up these
values in their products but other providers let them pass.

This updates the functionality to drop these cache control values so that
`akamai-rspec` doesn't cry when they are mismatching.